### PR TITLE
[docs] fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This package uses [typst-test](https://github.com/tingerrr/typst-test/) for runn
   - `slice()` has no `dx` and `dy` parameters anymore. Instead, labels are handled through `label` exactly as in `gate()`. Also the `wires` parameter is replaced with `n` for consistency with other multi-qubit gates. 
   - Swap order of row and column parameters in `annotate()` to make it consistent with built-in Typst functions. 
 - Improvements: 
-  - Improve layout (allow row/column spacing and min lengths to be specified in em-lenghts).
+  - Improve layout (allow row/column spacing and min lengths to be specified in em-lengths).
   - Automatic bounds computation, even for labels. 
   - Improve meter (allow multi-qubit gate meters and respect global (per-circuit) gate padding).d
 - Fixes:

--- a/docs/guide/quill-guide.typ
+++ b/docs/guide/quill-guide.typ
@@ -482,7 +482,7 @@ Quill allows you to create totally customized gates by specifying the `draw-func
 
 _Note, that the interface for custom gates might still change a bit. _
 
-When the circuit is layed out, the draw function is called with two (read-only) arguments: the gate itself and a dictionary that contains information about the circuit style and more. 
+When the circuit is laid out, the draw function is called with two (read-only) arguments: the gate itself and a dictionary that contains information about the circuit style and more. 
 
 Let us look at a little example for a custom gate that just shows the vertical lines of the box but not the horizontal ones. 
 

--- a/docs/guide/typst-doc.typ
+++ b/docs/guide/typst-doc.typ
@@ -171,7 +171,7 @@
 /// The function documentation dictionaries contain the keys
 /// - `name`: The function name.
 /// - `description`: The functions docstring description.
-/// - `args`: A dictionary of info objects for each fucntion argument.
+/// - `args`: A dictionary of info objects for each function argument.
 ///
 /// These again are dictionaries with the keys
 /// - `description` (optional): The description for the argument.

--- a/src/gates.typ
+++ b/src/gates.typ
@@ -15,7 +15,7 @@
 /// - content (content): What to show in the gate (may be none for special gates like @@ctrl() ).
 /// - x (auto, int): The column to put the gate in. 
 /// - y (auto, int): The row to put the gate in. 
-/// - fill (none, color): Gate backgrond fill color.
+/// - fill (none, color): Gate background fill color.
 /// - radius (length, dictionary): Gate rectangle border radius. 
 ///             Allows the same values as the builtin `rect()` function.
 /// - width (auto, length): The width of the gate can be specified manually with this property. 
@@ -83,7 +83,7 @@
 /// - y (auto, int): The row to put the gate in. 
 /// - target (none, int): If specified, a control wire is drawn from the gate up 
 ///        or down this many wires counted from the wire this `mqgate()` is placed on. 
-/// - fill (none, color): Gate backgrond fill color.
+/// - fill (none, color): Gate background fill color.
 /// - radius (length, dictionary): Gate rectangle border radius. 
 ///        Allows the same values as the builtin `rect()` function.
 /// - width (auto, length): The width of the gate can be specified manually with this property. 

--- a/src/quill.typ
+++ b/src/quill.typ
@@ -40,7 +40,7 @@
 ///            content or a string is given, the baseline will be adjusted auto-
 ///            matically to align with the center of it. One useful application is 
 ///            `"="` so the circuit aligns with the equals symbol. 
-/// - circuit-padding (dictionary): Padding for the circuit (e.g., to accomodate 
+/// - circuit-padding (dictionary): Padding for the circuit (e.g., to accommodate 
 ///            for annotations) in form of a dictionary with possible keys 
 ///            `left`, `right`, `top` and `bottom`. Not all of those need to be 
 ///            specified. 

--- a/src/quill2.typ
+++ b/src/quill2.typ
@@ -41,7 +41,7 @@
 ///            content or a string is given, the baseline will be adjusted auto-
 ///            matically to align with the center of it. One useful application is 
 ///            `"="` so the circuit aligns with the equals symbol. 
-/// - circuit-padding (dictionary): Padding for the circuit (e.g., to accomodate 
+/// - circuit-padding (dictionary): Padding for the circuit (e.g., to accommodate 
 ///            for annotations) in form of a dictionary with possible keys 
 ///            `left`, `right`, `top` and `bottom`. Not all of those need to be 
 ///            specified. 


### PR DESCRIPTION
Found via `typos --hidden --format brief`